### PR TITLE
fix: run eslint on all files in pre-commit

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -96,7 +96,8 @@ jobs:
 
   test-app:
     runs-on: ubuntu-22.04-arm
-    if: ${{ !github.event.pull_request.draft }}
+    # Do not run this step on the template service base repository as a Makefile is not yet defined.
+    if: ${{ !github.event.pull_request.draft && github.repository != 'OrcaBus/template-service-base' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,9 @@ repos:
     rev: v9.17.0
     hooks:
       - id: eslint
-        exclude: ^(pnpm-lock.yaml)
+        files: \.(m|c)?[jt]sx?$
+        types: [ file ]
+        exclude: pnpm-lock.yaml
 
   - repo: local
     hooks:

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript-eslint": "^8.28.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.185.0",
+    "aws-cdk-lib": "^2.195.0",
     "constructs": "^10.4.2",
     "@orcabus/platform-cdk-constructs": "0.0.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@orcabus/platform-cdk-constructs':
         specifier: 0.0.6
-        version: 0.0.6(aws-cdk-lib@2.188.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.0.6(aws-cdk-lib@2.195.0(constructs@10.4.2))(constructs@10.4.2)
       aws-cdk-lib:
-        specifier: ^2.185.0
-        version: 2.188.0(constructs@10.4.2)
+        specifier: ^2.195.0
+        version: 2.195.0(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
@@ -32,7 +32,7 @@ importers:
         version: 2.1007.0
       cdk-nag:
         specifier: ^2.35.56
-        version: 2.35.66(aws-cdk-lib@2.188.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.35.66(aws-cdk-lib@2.195.0(constructs@10.4.2))(constructs@10.4.2)
       eslint:
         specifier: ^9.23.0
         version: 9.24.0
@@ -582,8 +582,8 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
-  aws-cdk-lib@2.188.0:
-    resolution: {integrity: sha512-RiAkyKHUYcpI59IXP6VP1NvO0Ph5vlqIsrz6YE8KPuGfQ0LuE5ob4Ta2ibVs/fvaGyJIZkEPw54hDrytVWrk3g==}
+  aws-cdk-lib@2.195.0:
+    resolution: {integrity: sha512-AYLysgSjSnSjkal/AmR86DqvOVqy0VjeWmXR+ucIIGSOzJsevsYuNWCeVnf4v9x+vd2ysVcO8fXndG426vGZ/w==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -2150,9 +2150,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@orcabus/platform-cdk-constructs@0.0.6(aws-cdk-lib@2.188.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@orcabus/platform-cdk-constructs@0.0.6(aws-cdk-lib@2.195.0(constructs@10.4.2))(constructs@10.4.2)':
     dependencies:
-      aws-cdk-lib: 2.188.0(constructs@10.4.2)
+      aws-cdk-lib: 2.195.0(constructs@10.4.2)
       constructs: 10.4.2
 
   '@sinclair/typebox@0.27.8': {}
@@ -2350,7 +2350,7 @@ snapshots:
 
   async@3.2.6: {}
 
-  aws-cdk-lib@2.188.0(constructs@10.4.2):
+  aws-cdk-lib@2.195.0(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.231
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
@@ -2456,9 +2456,9 @@ snapshots:
 
   caniuse-lite@1.0.30001712: {}
 
-  cdk-nag@2.35.66(aws-cdk-lib@2.188.0(constructs@10.4.2))(constructs@10.4.2):
+  cdk-nag@2.35.66(aws-cdk-lib@2.195.0(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.188.0(constructs@10.4.2)
+      aws-cdk-lib: 2.195.0(constructs@10.4.2)
       constructs: 10.4.2
 
   chalk@4.1.2:

--- a/test/stage.test.ts
+++ b/test/stage.test.ts
@@ -40,9 +40,16 @@ describe('cdk-nag-stateless-toolchain-stack', () => {
  * @param stack
  */
 function applyNagSuppression(stack: Stack) {
+  // These are example suppressions for this stack and should be removed and replaced with the
+  // service-specific suppressions of your app.
   NagSuppressions.addStackSuppressions(
     stack,
     [{ id: 'AwsSolutions-S10', reason: 'not require requests to use SSL' }],
+    true
+  );
+  NagSuppressions.addStackSuppressions(
+    stack,
+    [{ id: 'AwsSolutions-S1', reason: 'this is an example bucket' }],
     true
   );
 }


### PR DESCRIPTION
### Changes
* Runs the eslint pre-commit on .ts files (and .mjs) as it doesn't run by default according to the docs: https://github.com/pre-commit/mirrors-eslint?tab=readme-ov-file#eslint-mirror
* Also updated aws-cdk-lib version, disabled the `test-app` step for this repository only (as there is no Makefile in that directory), and added another cdk-nag suppression